### PR TITLE
check if itemlocationmixin is valid

### DIFF
--- a/addons/main/main.lua
+++ b/addons/main/main.lua
@@ -204,13 +204,12 @@ function Scrap:IsLowEquip(slot, level)
 	end
 end
 
-function Scrap:IsBetterEquip(slot, level, canEmpty)
+function Scrap:IsBetterEquip(slot, level)
 	local item = ItemLocation:CreateFromEquipmentSlot(_G[slot])
-	if C_Item.GetItemID(item) then
+	if item:IsValid() then
 		return (C_Item.GetCurrentItemLevel(item) or 0) >= (level * 1.3)
-	elseif canEmpty then
-		return true
 	end
+	return true
 end
 
 
@@ -220,7 +219,7 @@ function Scrap:GuessLocation(...)
 	local bag, slot = self:GuessBagSlot(...)
 	if bag and slot then
 		local location = ItemLocation:CreateFromBagAndSlot(bag, slot)
-		if C_Item.GetItemID(location) then
+		if location:IsValid() then
 			return location
 		end
 	end


### PR DESCRIPTION
Uses `IsValid()` instead of `GetItemID` to verify item is valid.

Possibly fixes #159 and #156 

This bug was popping up for me when my character had a 2-handed weapon equipped. The `GetItemID` call would error when called on the offhand slot. It also seems `IsBetterEquip` is not being called with `RING2` or `TRINKET2` (or whatever those slots are called) as intended - not addressed in this PR.