### PR TITLE
Resolve missing dependencies when on-demand loading "Config" addon, fixes #241

### DIFF
--- a/addons/main/main.lua
+++ b/addons/main/main.lua
@@ -37,6 +37,7 @@ function Scrap:OnEnable()
 	self:OnSettings()
 
 	CreateFrame('Frame', nil, SettingsPanel or InterfaceOptionsFrame):SetScript('OnShow', function()
+		LoadAddOn('Scrap_Merchant')
 		LoadAddOn('Scrap_Config')
 	end)
 end


### PR DESCRIPTION
The internal addon Config sometimes has an unresolved dependency on the internal addon Merchant, wherein tutorial.lua needs both Scrap.Merchant and Scrap.Visualizer to already exist upon calling Load() within tutorials.lua. Prior to this patch, opening the settings window prior to opening a merchant window would always result in an error when querying Scrap.Visualizer.ParentTab as Scrap.Visualizer would be undefined. This patch simply loads the Merchant internal addon just before loading the Config internal addon to make sure these dependencies are resolved.