### PR TITLE
Updated Scrap-Mainline.toc for WoW 10.2.5

### DIFF
--- a/Scrap-Mainline.toc
+++ b/Scrap-Mainline.toc
@@ -8,7 +8,7 @@
 ## OptionalDeps: BagBrother, WoWUnit
 ## SavedVariablesPerCharacter: Scrap_CharSets
 ## SavedVariables: Scrap_Sets
-## Interface: 100200
+## Interface: 100205
 ## Version: 10.2.7
 
 addons\main\main.xml


### PR DESCRIPTION
Change versoin number for not error on wow on 10.2.5 Change; Interface: 100200 -> Interface: 100205